### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -28,7 +28,7 @@ const actionsDefinitions = {
     },
     baz: {
       type: 'better-promise',
-      sync: actionParam => return actionParam * 2,
+      sync: actionParam => actionParam * 2,
     },
   },
 };


### PR DESCRIPTION
Fix `SyntaxError: Unexpected token return` from Readme example